### PR TITLE
[SPARK-12248][CORE] Adds memory / heap limits per cpu for mesos coarse

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -326,9 +326,12 @@ private[mesos] trait MesosSchedulerUtils extends Logging {
    *         (whichever is larger)
    */
   def calculateTotalMemory(sc: SparkContext): Int = {
+   calculateMemoryOverhead(sc) + sc.executorMemory
+  }
+
+  def calculateMemoryOverhead(sc: SparkContext): Int = {
     sc.conf.getInt("spark.mesos.executor.memoryOverhead",
-      math.max(MEMORY_OVERHEAD_FRACTION * sc.executorMemory, MEMORY_OVERHEAD_MINIMUM).toInt) +
-      sc.executorMemory
+      math.max(MEMORY_OVERHEAD_FRACTION * sc.executorMemory, MEMORY_OVERHEAD_MINIMUM).toInt)
   }
 
   def setupUris(uris: String, builder: CommandInfo.Builder): Unit = {


### PR DESCRIPTION
- Add spark.cores.mb.min for minimum memory per core
- Add spark.cores.mb.max for max memory per core
- Modifies the behavior of the coarse executor to now account for an overhead, and assign heap related to total memory available minus the overhead
