### PR TITLE
[SPARK-19698] Fix possible race condition in task completions

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -552,11 +552,9 @@ class DAGScheduler(
    * @param callSite where in the user program this job was called
    * @param resultHandler callback to pass each result to
    * @param properties scheduler properties to attach to this job, e.g. fair scheduler pool name
-   *
-   * @return a JobWaiter object that can be used to block until the job finishes executing
+    * @return a JobWaiter object that can be used to block until the job finishes executing
    *         or can be used to cancel the job.
-   *
-   * @throws IllegalArgumentException when partitions ids are illegal
+    * @throws IllegalArgumentException when partitions ids are illegal
    */
   def submitJob[T, U](
       rdd: RDD[T],
@@ -599,8 +597,7 @@ class DAGScheduler(
    * @param callSite where in the user program this job was called
    * @param resultHandler callback to pass each result to
    * @param properties scheduler properties to attach to this job, e.g. fair scheduler pool name
-   *
-   * @throws Exception when the job fails
+    * @throws Exception when the job fails
    */
   def runJob[T, U](
       rdd: RDD[T],
@@ -1152,7 +1149,10 @@ class DAGScheduler(
             val resultStage = stage.asInstanceOf[ResultStage]
             resultStage.activeJob match {
               case Some(job) =>
-                if (!job.finished(rt.outputId)) {
+                if (
+                  rt.stageAttemptId == resultStage.latestInfo.attemptId &&
+                  !job.finished(rt.outputId)
+                ) {
                   updateAccumulators(event)
                   job.finished(rt.outputId) = true
                   job.numFinished += 1

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -552,9 +552,10 @@ class DAGScheduler(
    * @param callSite where in the user program this job was called
    * @param resultHandler callback to pass each result to
    * @param properties scheduler properties to attach to this job, e.g. fair scheduler pool name
-    * @return a JobWaiter object that can be used to block until the job finishes executing
+   *
+   * @return a JobWaiter object that can be used to block until the job finishes executing
    *         or can be used to cancel the job.
-    * @throws IllegalArgumentException when partitions ids are illegal
+   * @throws IllegalArgumentException when partitions ids are illegal
    */
   def submitJob[T, U](
       rdd: RDD[T],
@@ -597,7 +598,7 @@ class DAGScheduler(
    * @param callSite where in the user program this job was called
    * @param resultHandler callback to pass each result to
    * @param properties scheduler properties to attach to this job, e.g. fair scheduler pool name
-    * @throws Exception when the job fails
+   * @throws Exception when the job fails
    */
   def runJob[T, U](
       rdd: RDD[T],


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DAGScheduler` now checks task's stage attempt ID before marking the output as finished. As a result, task completions from the stale attempt won't make the scheduler think that the job has finished. This can benefit us by keeping the consistent state of things when there's a state manipulation somewhere during `ResultStage`. However, this could lead to a performance regression since the job won't be able to finish when all the tasks are "completed" by partially from the old and new attempts. 

Here's a possible scenario where the inconsistency can lead to a "wrong" result:

1) There's a ResultStage (a.k.a. Stage 1 for example) with 50 tasks where each task uploads a file to S3 using an underlying s3n storage implementation. After finishing only 5 tasks, it fails with `FetchFailedException`, so `DAGScheduler` resubmits the stage the remaining 40 tasks (2nd attempt, a.k.a. 1.1).
2) The remaining 40 tasks from stage 1 first attempt (a.k.a. 1.0) are still running. Some tasks, including a task that was responsible for partition 35 (Task A), finish. As a result, on S3, a file called `35.dummy` gets created. The task completion gets reported to the scheduler and the scheduler marks the partitions as finished.
3) all 40 tasks from 1.1 are running as well, uploading files to S3. There's a task, Task B, in this attempt that is responsible for partition 35. On its first attempt, the task successfully deletes `35.dummy` file created by the task in 1.0 because removal of the existing file is required. However, some error happens at underlying mechanism of uploading the file, so the first attempt fails. There's no `35.dummy` file anymore because it was deleted at first, and a new attempt for this task gets launched (Task B.1). 
4) Meanwhile, some other tasks from 1.1 and 1.0 completed that were responsible for all other partitions finish. Since the scheduler marked partition 35 as "finished" because Task A from 1.0 finished successfully, it concludes that the job is done and shuts down the job before Task B.1 finishes.
5) Now there's no `35.dummy` file on S3.

## How was this patch tested?

Unit test. Will be testing on my own setup.
