### PR TITLE
jets3t with aws v4 as a default signature mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## This branch applies the following additional commits:
  
+ - Jets3t updated to fix aws v4 signatures
+
  - Fix a bug in Netty - c7bd2bb13840f95bce016579b223a440d9354fda
 
  - CodeStyle Edits - ee8621ee423e6ed28913d9f7abb825e957a556d5

--- a/pom.xml
+++ b/pom.xml
@@ -2545,7 +2545,7 @@
       <id>hadoop-2.3</id>
       <properties>
         <hadoop.version>2.3.0</hadoop.version>
-        <jets3t.version>0.9.5-mmx1</jets3t.version>
+        <jets3t.version>0.9.5-mmx2</jets3t.version>
       </properties>
     </profile>
 
@@ -2553,7 +2553,7 @@
       <id>hadoop-2.4</id>
       <properties>
         <hadoop.version>2.4.1</hadoop.version>
-        <jets3t.version>0.9.5-mmx1</jets3t.version>
+        <jets3t.version>0.9.5-mmx2</jets3t.version>
       </properties>
     </profile>
 
@@ -2561,7 +2561,7 @@
       <id>hadoop-2.6</id>
       <properties>
         <hadoop.version>2.6.4</hadoop.version>
-        <jets3t.version>0.9.5-mmx1</jets3t.version>
+        <jets3t.version>0.9.5-mmx2</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <curator.version>2.6.0</curator.version>
       </properties>
@@ -2571,7 +2571,7 @@
       <id>hadoop-2.7</id>
       <properties>
         <hadoop.version>2.7.3</hadoop.version>
-        <jets3t.version>0.9.5-mmx1</jets3t.version>
+        <jets3t.version>0.9.5-mmx2</jets3t.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <curator.version>2.6.0</curator.version>
       </properties>


### PR DESCRIPTION
Follow up to #34 
In version 0.9.5-mmx2 of jets3t AWS v4 signature is not only fixed but also set as default so we don't need to override it in our configs and it works for all regions.   